### PR TITLE
Change to concurrent network battle launching

### DIFF
--- a/Assets/Scripts/Battle/BattleManager.cs
+++ b/Assets/Scripts/Battle/BattleManager.cs
@@ -393,8 +393,8 @@ namespace Battle
 
                 yield return new WaitUntil(() =>
                 {
-                    return battleData.participantPlayer.actionHasBeenChosen
-                    && battleData.participantOpponent.actionHasBeenChosen;
+                    return battleData.participantPlayer.GetActionHasBeenChosen()
+                    && battleData.participantOpponent.GetActionHasBeenChosen();
                 });
 
                 SetPlayerPokemonBobbingState(false);
@@ -406,8 +406,8 @@ namespace Battle
 
                 BattleParticipant.Action[] actionsUnsortedArray = new BattleParticipant.Action[]
                 {
-                    battleData.participantPlayer.chosenAction,
-                    battleData.participantOpponent.chosenAction
+                    battleData.participantPlayer.GetChosenAction(),
+                    battleData.participantOpponent.GetChosenAction()
                 };
 
                 Queue<BattleParticipant.Action> actionQueue = new Queue<BattleParticipant.Action>(
@@ -774,11 +774,11 @@ namespace Battle
 
                 textBoxController.SetTextInstant("Select your next pokemon");
 
-                yield return new WaitUntil(() => battleData.participantPlayer.nextPokemonHasBeenChosen);
+                yield return new WaitUntil(() => battleData.participantPlayer.GetNextPokemonHasBeenChosen());
 
                 textBoxController.SetTextInstant("");
 
-                battleData.participantPlayer.activePokemonIndex = battleData.participantPlayer.chosenNextPokemonIndex;
+                battleData.participantPlayer.activePokemonIndex = battleData.participantPlayer.GetChosenNextPokemonIndex();
 
                 battleAnimationSequencer.EnqueueSingleText(GetReplacedPokemonMessage(battleData.participantPlayer));
                 battleAnimationSequencer.EnqueueAnimation(new BattleAnimationSequencer.Animation()
@@ -797,9 +797,9 @@ namespace Battle
 
                 battleData.participantOpponent.StartChoosingNextPokemon();
 
-                yield return new WaitUntil(() => battleData.participantOpponent.nextPokemonHasBeenChosen);
+                yield return new WaitUntil(() => battleData.participantOpponent.GetNextPokemonHasBeenChosen());
 
-                battleData.participantOpponent.activePokemonIndex = battleData.participantOpponent.chosenNextPokemonIndex;
+                battleData.participantOpponent.activePokemonIndex = battleData.participantOpponent.GetChosenNextPokemonIndex();
 
                 battleAnimationSequencer.EnqueueSingleText(GetReplacedPokemonMessage(battleData.participantOpponent));
                 battleAnimationSequencer.EnqueueAnimation(new BattleAnimationSequencer.Animation()

--- a/Assets/Scripts/Battle/BattleManagerCheats.cs
+++ b/Assets/Scripts/Battle/BattleManagerCheats.cs
@@ -331,14 +331,13 @@ namespace Battle
             if (!useStruggle && PokemonMove.MoveIdIsUnset(battleData.participantOpponent.ActivePokemon.moveIds[moveIndex]))
                 return false;
 
-            battleData.participantOpponent.actionHasBeenChosen = true;
-            battleData.participantOpponent.chosenAction = new BattleParticipant.Action(battleData.participantOpponent)
+            battleData.participantOpponent.ForceSetChosenAction(new BattleParticipant.Action(battleData.participantOpponent)
             {
                 type = BattleParticipant.Action.Type.Fight,
                 fightMoveTarget = battleData.participantPlayer,
                 fightMoveIndex = useStruggle ? 0 : moveIndex,
                 fightUsingStruggle = useStruggle
-            };
+            });
 
             return true;
 
@@ -360,12 +359,11 @@ namespace Battle
             if (battleData.participantOpponent.GetPokemon()[partyIndex] == null)
                 return false;
 
-            battleData.participantOpponent.actionHasBeenChosen = true;
-            battleData.participantOpponent.chosenAction = new BattleParticipant.Action(battleData.participantOpponent)
+            battleData.participantOpponent.ForceSetChosenAction(new BattleParticipant.Action(battleData.participantOpponent)
             {
                 type = BattleParticipant.Action.Type.SwitchPokemon,
                 switchPokemonIndex = partyIndex
-            };
+            });
 
             return true;
 
@@ -386,15 +384,14 @@ namespace Battle
             if (moveIndex < 0 && item is PPRestoreMedicineItem)
                 return false;
 
-            battleData.participantPlayer.actionHasBeenChosen = true;
-            battleData.participantPlayer.chosenAction = new BattleParticipant.Action(battleData.participantPlayer)
+            battleData.participantPlayer.ForceSetChosenAction(new BattleParticipant.Action(battleData.participantPlayer)
             {
                 type = BattleParticipant.Action.Type.UseItem,
                 useItemItemToUse = item,
                 useItemTargetPartyIndex = partyIndex >= 0 ? partyIndex : battleData.participantPlayer.activePokemonIndex,
                 useItemTargetMoveIndex = moveIndex,
                 useItemDontConsumeItem = true
-            };
+            });
 
             playerBattleUIController.DisableAllMenus();
 
@@ -417,14 +414,13 @@ namespace Battle
             if (moveIndex < 0 && item is PPRestoreMedicineItem)
                 return false;
 
-            battleData.participantOpponent.actionHasBeenChosen = true;
-            battleData.participantOpponent.chosenAction = new BattleParticipant.Action(battleData.participantOpponent)
+            battleData.participantOpponent.ForceSetChosenAction(new BattleParticipant.Action(battleData.participantOpponent)
             {
                 type = BattleParticipant.Action.Type.UseItem,
                 useItemItemToUse = item,
                 useItemTargetPartyIndex = partyIndex >= 0 ? partyIndex : battleData.participantOpponent.activePokemonIndex,
                 useItemTargetMoveIndex = moveIndex
-            };
+            });
             return true;
 
         }
@@ -435,14 +431,13 @@ namespace Battle
         public bool CheatCommand_SetPlayerAction_UseItem_PokeBall(Item pokeBall)
         {
 
-            battleData.participantPlayer.actionHasBeenChosen = true;
-            battleData.participantPlayer.chosenAction = new BattleParticipant.Action(battleData.participantPlayer)
+            battleData.participantPlayer.ForceSetChosenAction(new BattleParticipant.Action(battleData.participantPlayer)
             {
                 type = BattleParticipant.Action.Type.UseItem,
                 useItemItemToUse = pokeBall,
                 useItemPokeBallTarget = battleData.participantOpponent,
                 useItemDontConsumeItem = true
-            };
+            });
 
             playerBattleUIController.DisableAllMenus();
 

--- a/Assets/Scripts/Battle/BattleParticipant.cs
+++ b/Assets/Scripts/Battle/BattleParticipant.cs
@@ -16,14 +16,27 @@ namespace Battle
         /// <summary>
         /// Whether the action has been chosen
         /// </summary>
-        public bool actionHasBeenChosen = false;
+        protected bool actionHasBeenChosen = false;
+
+        public virtual bool GetActionHasBeenChosen() => actionHasBeenChosen;
 
         /// <summary>
         /// The action that has been chosen. This is only valid if actionHasBeenChosen is true
         /// </summary>
-        public Action chosenAction;
+        protected Action chosenAction;
+
+        public virtual Action GetChosenAction() => chosenAction;
 
         public abstract void StartChoosingAction(BattleData battleData);
+
+        /// <summary>
+        /// Forcefully set a participant's chosen action. Made for cheat commands
+        /// </summary>
+        public virtual void ForceSetChosenAction(Action action)
+        {
+            actionHasBeenChosen = true;
+            chosenAction = action;
+        }
 
         #endregion
 
@@ -50,12 +63,16 @@ namespace Battle
         /// <summary>
         /// Whether the next pokemon has been chosen
         /// </summary>
-        public bool nextPokemonHasBeenChosen = false;
+        protected bool nextPokemonHasBeenChosen = false;
+
+        public virtual bool GetNextPokemonHasBeenChosen() => nextPokemonHasBeenChosen;
 
         /// <summary>
         /// Index of pokemon chosen to replace current pokemon. This is only valid if nextPokemonHasBeenChosen is true
         /// </summary>
-        public int chosenNextPokemonIndex;
+        protected int chosenNextPokemonIndex;
+
+        public virtual int GetChosenNextPokemonIndex() => chosenNextPokemonIndex;
 
         public abstract void StartChoosingNextPokemon();
 

--- a/Assets/Scripts/Networking/Connection.cs
+++ b/Assets/Scripts/Networking/Connection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -8,6 +9,7 @@ using System.Threading;
 using UnityEngine;
 using Serialization;
 using Pokemon;
+using Battle;
 
 namespace Networking
 {
@@ -17,11 +19,17 @@ namespace Networking
         public const ushort pokemonObsidianIdentifier = 0x6f70;
         public static byte[] PokemonObsidianIdentifierBytes => BitConverter.GetBytes(pokemonObsidianIdentifier);
 
-        public const uint acknowledgementCode = 0x706b6361;
-        public static byte[] AcknowledgementCodeBytes => BitConverter.GetBytes(acknowledgementCode);
+        public const uint yesCode = 0x706b6361;
+        public static byte[] YesCodeBytes => BitConverter.GetBytes(yesCode);
 
-        public const uint failedToReceiveCode = 0x6e686170;
-        public static byte[] FailedToReceiveCodeBytes => BitConverter.GetBytes(failedToReceiveCode);
+        public const uint noCode = 0x6e686170;
+        public static byte[] NoCodeBytes => BitConverter.GetBytes(noCode);
+
+        public const uint networkBattleCommActionCode = 0x809ef0ab;
+        public static byte[] NetworkBattleCommActionCodeBytes => BitConverter.GetBytes(networkBattleCommActionCode);
+
+        public const uint networkBattleCommChosenPokemonCode = 0x809fceab;
+        public static byte[] NetworkBattleCommChosenPokemonCodeBytes => BitConverter.GetBytes(networkBattleCommChosenPokemonCode);
 
         public const int mainPort = 59004;
         public const int discoveryPort = 59005;
@@ -39,34 +47,42 @@ namespace Networking
                 .ToArray()[0];
         }
 
-        private static void LogNetworkEvent(string msg)
+        public delegate void LogCallback(string msg);
+
+        public static void LogNetworkEvent(string msg)
         {
             if (GameSettings.singleton.networkLogEnabled)
                 Debug.Log(msg);
         }
 
-        private static void LogNetworkEventSocketIsConnected(Socket socket)
-        {
-            LogNetworkEvent("Socket connected - " + (socket.Connected ? "yes" : "no"));
-        }
-
         #region Standard Codes
 
-        private static void SendAck(NetworkStream stream)
+        private static void SendYes(NetworkStream stream)
         {
-            stream.Write(AcknowledgementCodeBytes, 0, 4);
+            stream.Write(YesCodeBytes, 0, 4);
         }
 
-        private static bool TryReceiveAck(NetworkStream stream)
+        private static void SendNo(NetworkStream stream)
+        {
+            stream.Write(NoCodeBytes, 0, 4);
+        }
+
+        private static bool? TryReceiveResponseYN(NetworkStream stream,
+            out uint recvAck)
         {
 
             byte[] buffer = new byte[4];
 
             stream.Read(buffer, 0, 4);
 
-            uint recvAck = BitConverter.ToUInt32(buffer, 0);
+            recvAck = BitConverter.ToUInt32(buffer, 0);
 
-            return recvAck == acknowledgementCode;
+            if (recvAck == yesCode)
+                return true;
+            else if (recvAck == noCode)
+                return false;
+            else
+                return null;
 
         }
 
@@ -75,16 +91,56 @@ namespace Networking
             stream.Write(PokemonObsidianIdentifierBytes, 0, 2);
         }
 
-        private static bool TryReceivePokemonObsidianIdentifier(NetworkStream stream)
+        private static bool TryReceivePokemonObsidianIdentifier(NetworkStream stream,
+            out ushort recvPmonId)
         {
 
             byte[] buffer = new byte[2];
 
             stream.Read(buffer, 0, 2);
 
-            ushort recvPmonId = BitConverter.ToUInt16(buffer, 0);
+            recvPmonId = BitConverter.ToUInt16(buffer, 0);
 
             return recvPmonId == pokemonObsidianIdentifier;
+
+        }
+
+        private static void SendNetworkBattleCommType(NetworkStream stream, NetworkBattleCommType type)
+        {
+
+            switch (type)
+            {
+
+                case NetworkBattleCommType.Action:
+                    stream.Write(NetworkBattleCommActionCodeBytes, 0, 4);
+                    break;
+
+                case NetworkBattleCommType.ChosenPokemon:
+                    stream.Write(NetworkBattleCommChosenPokemonCodeBytes, 0, 4);
+                    break;
+
+                default:
+                    throw new Exception("Unknown type");
+
+            }
+
+        }
+
+        private static NetworkBattleCommType? ReceiveNetworkBattleCommType(NetworkStream stream)
+        {
+
+            byte[] buffer = new byte[4];
+
+            stream.Read(buffer, 0, 4);
+
+            uint recvCode = BitConverter.ToUInt32(buffer, 0);
+
+            if (recvCode == networkBattleCommActionCode)
+                return NetworkBattleCommType.Action;
+            else if (recvCode == networkBattleCommChosenPokemonCode)
+                return NetworkBattleCommType.ChosenPokemon;
+            else
+                return null;
 
         }
 
@@ -94,7 +150,8 @@ namespace Networking
 
         /// <param name="port">The port to use. Negative means to use the default port</param>
         public static bool TryConnectToServer(out Socket socket,
-            out string errMsg,
+            LogCallback errCallback,
+            LogCallback statusCallback,
             string ipAddress,
             int port)
         {
@@ -108,18 +165,19 @@ namespace Networking
             catch (NullReferenceException)
             {
                 socket = default;
-                errMsg = "IP address provided is null";
+                errCallback("IP address provided is null");
                 return false;
             }
             catch (FormatException)
             {
                 socket = default;
-                errMsg = "Invalid IP address format";
+                errCallback("Invalid IP address format");
                 return false;
             }
 
             return TryConnectToServer(out socket,
-                out errMsg,
+                errCallback,
+                statusCallback,
                 address,
                 port);
 
@@ -127,9 +185,10 @@ namespace Networking
 
         /// <param name="port">The port to use. Negative means to use the default port</param>
         public static bool TryConnectToServer(out Socket socket,
-            out string errMsg,
+            LogCallback errCallback,
+            LogCallback statusCallback,
             IPAddress ipAddress,
-            int port)
+            int port = -1)
         {
 
             if (port < 0)
@@ -138,22 +197,22 @@ namespace Networking
             if (port < IPEndPoint.MinPort)
             {
                 socket = default;
-                errMsg = "Port number provided too small";
+                errCallback("Port number provided too small");
                 return false;
             }
 
             if (port > IPEndPoint.MaxPort)
             {
                 socket = default;
-                errMsg = "Port number provided too great";
+                errCallback("Port number provided too great");
                 return false;
             }
 
             socket = new Socket(socketType, protocolType);
-            LogNetworkEvent($"Socket created (local endpoint - {socket.LocalEndPoint})");
+            LogNetworkEvent($"Socket created");
 
             IPEndPoint endPoint = new IPEndPoint(ipAddress, port);
-            LogNetworkEvent($"Socket end point set to {ipAddress}:{port}");
+            LogNetworkEvent($"Socket end point is {ipAddress}:{port}");
 
             if (!GameSettings.singleton.networkTimeoutDisabled)
             {
@@ -164,133 +223,177 @@ namespace Networking
             try
             {
 
-                if (!GameSettings.singleton.networkTimeoutDisabled)
-                {
-                    IAsyncResult connectResult = socket.BeginConnect(endPoint, null, null);
-                    LogNetworkEvent("Started connecting socket");
-                    if (connectResult.AsyncWaitHandle.WaitOne(defaultTimeout, true))
-                    {
-                        LogNetworkEvent("Socket connected");
-                        socket.EndConnect(connectResult);
-                    }
-                    else
-                    {
-                        socket.Close();
-                        errMsg = "Connection timed out";
-                        LogNetworkEvent("Connection timed out");
-                        return false;
-                    }
-                }
-                else
-                {
-                    LogNetworkEvent("Connecting socket...");
-                    socket.Connect(endPoint);
-                    LogNetworkEvent("Socket connected");
-                }
+                statusCallback("Connecting to server...");
+                socket.Connect(endPoint);
+                LogNetworkEvent("Connected to server");
+                statusCallback("Connected to server");
 
             }
             catch (SocketException e)
             {
                 socket.Close();
-                errMsg = "Socket Error: " + e.Message;
+                errCallback("Socket Error: " + e.Message);
                 LogNetworkEvent("Socket Error Message: \"" + e.Message + "\". Error Stack: " + e.StackTrace);
                 return false;
             }
             catch (ObjectDisposedException)
             {
                 socket.Close();
-                errMsg = "Socket closed unexpectedly";
+                errCallback("Socket closed unexpectedly");
                 return false;
             }
             catch (System.Security.SecurityException)
             {
                 socket.Close();
-                errMsg = "Invalid permissions";
+                errCallback("Invalid permissions");
                 return false;
             }
             catch (InvalidOperationException)
             {
                 socket.Close();
-                errMsg = "Socket unexpectedly in listening mode";
+                errCallback("Socket unexpectedly in listening mode");
                 return false;
             }
-
-            errMsg = default;
+            
             return true;
 
         }
 
-        public delegate void StartedListening();
-        public delegate void ClientConnected(bool success, string errMsg, Socket socket);
+        public delegate void StartedListening(IPEndPoint endPoint);
+        public delegate void ClientConnected(bool success, Socket socket);
 
         /// <param name="port">The port to use. Negative means to use the default port</param>
-        public async static void TryStartHostServer(StartedListening startedListeningListener,
+        /// <param name="clientConnectedListener">The function to call when a client is connected. ONLY FOR SYNCHRONOUS MODE</param>
+        public static void TryStartHostServer(StartedListening startedListeningListener,
             ClientConnected clientConnectedListener,
-            int port = -1)
-        {
-
-            await Task.Run(() =>
-                TryHostServer(startedListeningListener, clientConnectedListener, port)
-            );
-
-        }
-
-        /// <param name="port">The port to use. Negative means to use the default port</param>
-        private static void TryHostServer(StartedListening startedListeningListener,
-            ClientConnected clientConnectedListener,
-            int port = -1)
+            LogCallback errCallback,
+            LogCallback statusCallback,
+            int port = -1,
+            bool useAsync = true)
         {
 
             if (port < 0)
                 port = mainPort;
 
-            if (port < IPEndPoint.MinPort)
+            IPEndPoint ep = new IPEndPoint(GetHostIPAddress(), port);
+
+            if (!useAsync)
             {
-                clientConnectedListener?.Invoke(false, "Port number provided too small", default);
-            }
 
-            if (port > IPEndPoint.MaxPort)
+                Socket sock = SyncServerListening(ep,
+                    errCallback,
+                    statusCallback);
+
+                startedListeningListener?.Invoke(ep);
+
+                clientConnectedListener?.Invoke(
+                    true,
+                    sock);
+
+            }
+            else
             {
-                clientConnectedListener?.Invoke(false, "Port number provided too great", default);
+
+                statusCallback("Awaiting connection...");
+
+                StartAsyncServerListening(ep, errCallback, statusCallback);
+
+                startedListeningListener?.Invoke(ep);
+
             }
-
-            Socket socket = new Socket(socketType, protocolType);
-            LogNetworkEvent("Socket created");
-
-            IPEndPoint endPoint = new IPEndPoint(GetHostIPAddress(), port);
-
-            socket.Bind(endPoint);
-            LogNetworkEvent($"Socket bound to {endPoint.Address}:{port}");
-
-            socket.Listen(1);
-            LogNetworkEvent("Socket set to listen");
-
-            startedListeningListener?.Invoke();
-
-            Socket cliSocket;
-
-            LogNetworkEvent("Awaiting connection");
-
-            try
-            {
-                cliSocket = socket.Accept();
-            }
-            catch (SocketException e)
-            {
-                clientConnectedListener?.Invoke(false, "Socket Error: " + e.Message, default);
-                return;
-            }
-            catch (ObjectDisposedException)
-            {
-                clientConnectedListener?.Invoke(false, "Socket closed unexpectedly", default);
-                return;
-            }
-
-            LogNetworkEvent("Connection accepted");
-
-            clientConnectedListener?.Invoke(true, "", cliSocket);
 
         }
+
+        public static Socket FetchAsyncNewClient()
+        {
+
+            if (asyncNewClient != null)
+            {
+                Socket s = asyncNewClient;
+                SetAsyncNewClient(null);
+                return s;
+            }
+            else
+                return null;
+
+        }
+
+        private static Socket SyncServerListening(IPEndPoint ep,
+            LogCallback errCallback,
+            LogCallback statusCallback)
+        {
+
+            Socket listenerSock = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            listenerSock.Bind(ep);
+            listenerSock.Listen(1);
+
+            statusCallback($"Waiting for other user at {ep.Address}:{ep.Port}...");
+
+            Socket sock = listenerSock.Accept();
+
+            statusCallback("Other user connected");
+
+            return sock;
+
+        }
+
+        private static void StartAsyncServerListening(IPEndPoint ep,
+            LogCallback errCallback,
+            LogCallback statusCallback)
+        {
+
+            awaitingClient = true;
+
+            Task serverTask = new Task(() => AsyncServerListeningTask(ep));
+
+            serverTask.Start();
+
+        }
+
+        #region Async Functionality
+
+        private static readonly object asyncNewClientLock = new object();
+        private static bool awaitingClient = false;
+        private static Socket asyncNewClient = null;
+
+        private static void SetAsyncNewClient(Socket sock)
+        {
+
+            lock (asyncNewClientLock)
+            {
+
+                if (sock == null)
+                    asyncNewClient = null;
+                else
+                {
+
+                    if (!awaitingClient)
+                        throw new Exception("Unecessary client connected");
+
+                    asyncNewClient = sock;
+                    awaitingClient = false;
+
+                }
+
+            }
+
+        }
+
+        private static void AsyncServerListeningTask(IPEndPoint ep)
+        {
+
+            Socket listenerSock = new Socket(SocketType.Stream, ProtocolType.Tcp);
+
+            listenerSock.Bind(ep);
+            listenerSock.Listen(1);
+
+            Socket sock = listenerSock.Accept();
+
+            SetAsyncNewClient(sock);
+
+        }
+
+        #endregion
 
         #endregion
 
@@ -302,6 +405,7 @@ namespace Networking
             //Having the network stream own the socket should make the socket close when the network stream is closed
             NetworkStream stream = new NetworkStream(socket, true);
             stream.ReadTimeout = GameSettings.singleton.networkTimeoutDisabled ? -1 : defaultTimeout;
+            stream.WriteTimeout = GameSettings.singleton.networkTimeoutDisabled ? -1 : defaultTimeout;
             return stream;
 
         }
@@ -310,7 +414,9 @@ namespace Networking
 
         #region Connection Verification
 
-        public static bool VerifyConnection_Client(NetworkStream stream)
+        public static bool VerifyConnection_Client(NetworkStream stream,
+            LogCallback errCallback,
+            LogCallback statusCallback)
         {
 
             LogNetworkEvent("Starting client connection verification");
@@ -324,32 +430,41 @@ namespace Networking
 
                 LogNetworkEvent("Receiving identifier...");
 
-                if (!TryReceivePokemonObsidianIdentifier(stream))
+                if (!TryReceivePokemonObsidianIdentifier(stream, out _))
                 {
-                    LogNetworkEvent("Identifier mismatch");
-                    Debug.LogWarning("Pokemon Obsidian Identifier mismatch");
+                    errCallback("Identifier mismatch");
+                    LogNetworkEvent("Pokemon Obsidian Identifier mismatch");
+                    SendNo(stream);
                     return false;
                 }
                 else
                 {
                     LogNetworkEvent("Identifier matches");
+                    SendYes(stream);
                 }
 
-                //Client sends acknowledgement
-                SendAck(stream);
-                LogNetworkEvent("Sent ack");
+                //Client sends Pokemon Obsidian Identifier
+                SendPokemonObsidianIdentifier(stream);
+                LogNetworkEvent("Sent identifier");
+
+                if (TryReceiveResponseYN(stream, out _) != true)
+                {
+                    errCallback("Failed to receive identifier yes response");
+                    return false;
+                }
 
                 //Server sends game version
                 buffer = new byte[2];
                 LogNetworkEvent("Receiving game version");
                 stream.Read(buffer, 0, 2);
-                LogNetworkEvent("Received game version");
+                statusCallback("Received game version");
                 ushort serverGameVersion = BitConverter.ToUInt16(buffer, 0);
 
                 if (serverGameVersion != GameVersion.version)
                 {
-                    LogNetworkEvent("Game version mismatch");
-                    Debug.LogWarning($"Game version mismatch (server - {serverGameVersion}, client - {GameVersion.version})");
+                    statusCallback("Mismatching game versions");
+                    errCallback("Game version mismatch");
+                    SendNo(stream);
                     return false;
                 }
 
@@ -362,29 +477,31 @@ namespace Networking
 
                 if (serverSerializerVersion != Serialize.defaultSerializerVersion)
                 {
-                    LogNetworkEvent("Serializer version mismatch");
-                    Debug.LogWarning($"Game version mismatch (server - {serverSerializerVersion}, client - {Serialize.defaultSerializerVersion})");
+                    statusCallback("Mismatching game versions");
+                    errCallback("Serializer version mismatch");
+                    SendNo(stream);
                     return false;
                 }
 
-                //Client sends acknowledgement
-                SendAck(stream);
+                //Client sends yes
+                SendYes(stream);
 
                 return true;
 
             }
             catch (IOException e) //It is assumed that the network stream timed out
             {
-                Debug.LogWarning("Network stream timed out");
-                LogNetworkEvent("IOException. Message: \"" + e.Message + "\" stack trace: " + e.StackTrace);
+                errCallback("IOException. Message: \"" + e.Message + "\" stack trace: " + e.StackTrace);
                 if (e.InnerException is SocketException sockE)
-                    LogNetworkEvent($"IOException's inner socket exception code: {sockE.SocketErrorCode}");
+                    errCallback($"IOException's inner socket exception code: {sockE.SocketErrorCode}");
                 return false;
             }
 
         }
 
-        public static bool VerifyConnection_Server(NetworkStream stream)
+        public static bool VerifyConnection_Server(NetworkStream stream,
+            LogCallback errCallback,
+            LogCallback statusCallback)
         {
 
             LogNetworkEvent("Starting server connection verification");
@@ -398,46 +515,45 @@ namespace Networking
                 SendPokemonObsidianIdentifier(stream);
                 LogNetworkEvent("Sent identifier");
 
-                //Client sends acknowledgement
-
-                LogNetworkEvent("Receiving ack...");
-
-                if (!TryReceiveAck(stream))
+                if (TryReceiveResponseYN(stream, out _) != true)
                 {
-                    LogNetworkEvent("Invalid ack");
-                    Debug.LogWarning("Incorrect acknowledgement code received");
+                    errCallback("Failed to receive identifier yes response");
+                    return false;
+                }
+
+                //Client sends Pokemon Obsidian Identifier
+
+                LogNetworkEvent("Receiving identifier...");
+
+                if (!TryReceivePokemonObsidianIdentifier(stream, out ushort recvPmonId))
+                {
+                    errCallback("Identifier mismatch");
+                    SendNo(stream);
                     return false;
                 }
                 else
                 {
-                    LogNetworkEvent("Successfully received ack");
+                    LogNetworkEvent("Identifier matches");
+                    SendYes(stream);
                 }
 
                 //Server sends game version
                 buffer = GameVersion.VersionBytes;
-                LogNetworkEvent("Sending game version...");
+                statusCallback("Sending game version...");
                 stream.Write(buffer, 0, 2);
-                LogNetworkEvent("Sent game version");
+                statusCallback("Sent game version");
 
                 //Server sends serializer version
                 buffer = BitConverter.GetBytes(Serialize.defaultSerializerVersion);
-                LogNetworkEvent("Sending serializer version...");
+                statusCallback("Sending serializer version...");
                 stream.Write(buffer, 0, 2);
-                LogNetworkEvent("Sent serializer version");
+                statusCallback("Sent serializer version");
 
-                //Client sends acknowledgement
-                
-                LogNetworkEvent("Receiving ack...");
-
-                if (!TryReceiveAck(stream))
+                if (TryReceiveResponseYN(stream, out _) != true)
                 {
-                    LogNetworkEvent("Invalid ack");
-                    Debug.LogWarning("Incorrect acknowledgement code received");
+                    statusCallback("Mismatching game versions");
+                    errCallback("Failed to receive versions yes response");
                     return false;
-                }
-                else
-                {
-                    LogNetworkEvent("Successfully received ack");
                 }
 
                 return true;
@@ -445,10 +561,9 @@ namespace Networking
             }
             catch (IOException e)
             {
-                Debug.LogWarning("Connection lost");
-                LogNetworkEvent("IOException. Message: \"" + e.Message + "\" stack trace: " + e.StackTrace);
+                errCallback("IOException. Message: \"" + e.Message + "\" stack trace: " + e.StackTrace);
                 if (e.InnerException is SocketException sockE)
-                    LogNetworkEvent($"IOException's inner socket exception code: {sockE.SocketErrorCode}");
+                    errCallback($"IOException's inner socket exception code: {sockE.SocketErrorCode}");
                 return false;
             }
 
@@ -458,73 +573,85 @@ namespace Networking
 
         #region Exchange Battle Entrance Arguments
 
-        private static void SendBattleEntranceArguments(NetworkStream stream,
+        private static bool TrySendBattleEntranceArguments(NetworkStream stream,
+            LogCallback errCallback,
+            LogCallback statusCallback,
             Serializer serializer,
             PlayerData player = null)
         {
 
-            LogNetworkEvent("Starting send battle arguments");
-
-            if (player == null)
-                player = PlayerData.singleton;
-
-            if (serializer == null)
-                serializer = Serialize.DefaultSerializer;
-
-            LogNetworkEvent("Sending name...");
-            serializer.SerializeString(stream, player.profile.name);
-            LogNetworkEvent("Sent name");
-
-            LogNetworkEvent("Starting to send party");
-
-            for (byte i = 0; i < PlayerData.partyCapacity; i++)
+            try
             {
 
-                PokemonInstance pokemon = player.partyPokemon[i];
+                LogNetworkEvent("Starting to send battle arguments");
 
-                if (pokemon == null)
+                LogNetworkEvent($"Sending name ({player.profile.name})...");
+                serializer.SerializeString(stream, player.profile.name);
+                LogNetworkEvent("Sent name");
+
+                LogNetworkEvent("Starting to send party pokemon...");
+
+                for (byte i = 0; i < PlayerData.partyCapacity; i++)
                 {
-                    LogNetworkEvent("Sending null pokemon...");
-                    serializer.SerializeBool(stream, false);
-                    LogNetworkEvent("Sent null pokemon");
+
+                    PokemonInstance pokemon = player.partyPokemon[i];
+
+                    if (pokemon == null)
+                    {
+                        LogNetworkEvent("Sending null pokemon...");
+                        serializer.SerializeBool(stream, false);
+                        LogNetworkEvent("Sent null pokemon");
+                    }
+                    else
+                    {
+
+                        LogNetworkEvent("Sending pokemon...");
+                        serializer.SerializeBool(stream, true);
+                        serializer.SerializePokemonInstance(stream, pokemon);
+                        LogNetworkEvent($"Sent pokemon {string.Format("{0:X}", pokemon.Hash)}");
+
+                    }
+
                 }
-                else
-                {
-                    LogNetworkEvent("Sending pokemon...");
-                    serializer.SerializeBool(stream, true);
-                    LogNetworkEvent($"Pmon EVs: {pokemon.effortValues.attack},{pokemon.effortValues.defense},{pokemon.effortValues.specialAttack},{pokemon.effortValues.specialDefense},{pokemon.effortValues.speed},{pokemon.effortValues.health}"); //TODO - remove once done debugging
-                    LogNetworkEvent($"Pmon IVs: {pokemon.individualValues.attack},{pokemon.individualValues.defense},{pokemon.individualValues.specialAttack},{pokemon.individualValues.specialDefense},{pokemon.individualValues.speed},{pokemon.individualValues.health}"); //TODO - remove once done debugging
-                    serializer.SerializePokemonInstance(stream, pokemon);
-                    LogNetworkEvent($"Sent pokemon  (Hash - {string.Format("{0:X}", pokemon.Hash)})");
-                }
+
+                LogNetworkEvent("Sent party pokemon");
+
+                LogNetworkEvent($"Sending sprite name ({player.profile.SpriteName})...");
+                serializer.SerializeString(stream, player.profile.SpriteName);
+                LogNetworkEvent("Sent sprite name");
+
+                LogNetworkEvent("Battle entrance arguments sent");
+
+                return true;
 
             }
-
-            LogNetworkEvent("Party sent");
-
-            LogNetworkEvent("Sending sprite name");
-            serializer.SerializeString(stream, player.profile.SpriteName);
-            LogNetworkEvent("Sent sprite name");
+            catch (IOException e)
+            {
+                errCallback("IOException\n-->Message: \"" + e.Message + "\"\n-->Stack Trace:\n" + e.StackTrace);
+                return false;
+            }
 
         }
 
         private static bool TryReceiveBattleEntranceArguments(NetworkStream stream,
+            LogCallback errCallback,
+            LogCallback statusCallback,
             Serializer serializer,
             out string name,
             out PokemonInstance[] pokemon,
             out string spriteResourceName)
         {
 
-            LogNetworkEvent("Starting receive battle arguments");
-
             try
             {
 
+                LogNetworkEvent("Starting to receive battle entrance arguments");
+
                 LogNetworkEvent("Receiving name...");
                 name = serializer.DeserializeString(stream);
-                LogNetworkEvent("Received name");
+                LogNetworkEvent($"Received name ({name})");
 
-                LogNetworkEvent("Starting to receive party");
+                LogNetworkEvent("Receiving party...");
 
                 pokemon = new PokemonInstance[PlayerData.partyCapacity];
 
@@ -542,9 +669,11 @@ namespace Networking
                     }
                     else
                     {
+
                         LogNetworkEvent("Receiving pokemon instance...");
                         pokemon[i] = serializer.DeserializePokemonInstance(stream);
                         LogNetworkEvent($"Received pokemon instance (Hash - {string.Format("{0:X}", pokemon[i].Hash)})");
+
                     }
 
                 }
@@ -560,8 +689,7 @@ namespace Networking
             }
             catch (IOException e)
             {
-                Debug.LogWarning("Connection error");
-                LogNetworkEvent("IOException. Message: \"" + e.Message + "\" stack trace: " + e.StackTrace);
+                errCallback("IOException\n-->Message: \"" + e.Message + "\"\n-->Stack Trace:\n" + e.StackTrace);
                 name = default;
                 pokemon = default;
                 spriteResourceName = default;
@@ -571,6 +699,8 @@ namespace Networking
         }
 
         public static bool TryExchangeBattleEntranceArguments_Client(NetworkStream stream,
+            LogCallback errCallback,
+            LogCallback statusCallback,
             out string name,
             out PokemonInstance[] pokemon,
             out string spriteResourceName,
@@ -585,31 +715,44 @@ namespace Networking
             try
             {
 
-                //Server sends battle entrance arguments
                 if (!TryReceiveBattleEntranceArguments(stream,
+                    errCallback,
+                    statusCallback,
                     serializer,
                     out name,
                     out pokemon,
                     out spriteResourceName))
                 {
 
-                    Debug.LogWarning("Failed to receive battle entrance arguments");
+                    errCallback("Failed to receive battle entrance arguments");
+                    SendNo(stream);
                     return false;
 
                 }
 
-                //Client sends acknowledgement
-                SendAck(stream);
+                SendYes(stream);
 
-                //Client sends battle entrance arguments
-                SendBattleEntranceArguments(stream, serializer, player);
-
-                //Server sends acknowledgement
-
-                if (!TryReceiveAck(stream))
+                if (!TrySendBattleEntranceArguments(stream,
+                    errCallback,
+                    statusCallback,
+                    serializer,
+                    player))
                 {
-                    Debug.LogWarning($"Incorrect acknowledgement code received");
+                    errCallback("Failed to send battle arguments");
                     return false;
+                }
+
+                switch (TryReceiveResponseYN(stream, out _))
+                {
+
+                    case false:
+                    case null:
+                        errCallback("Didn't receive yes after sending battle entrance arguments");
+                        return false;
+
+                    case true:
+                        break;
+
                 }
 
                 return true;
@@ -617,7 +760,7 @@ namespace Networking
             }
             catch (IOException)
             {
-                Debug.LogWarning("Connection lost");
+                errCallback("Connection lost");
                 name = default;
                 pokemon = default;
                 spriteResourceName = default;
@@ -627,6 +770,8 @@ namespace Networking
         }
 
         public static bool TryExchangeBattleEntranceArguments_Server(NetworkStream stream,
+            LogCallback errCallback,
+            LogCallback statusCallback,
             out string name,
             out PokemonInstance[] pokemon,
             out string spriteResourceName,
@@ -641,47 +786,300 @@ namespace Networking
             try
             {
 
-                //Server sends battle entrance arguments
-                SendBattleEntranceArguments(stream, serializer, player);
-
-                //Client sends acknowledgement
-
-                if (!TryReceiveAck(stream))
+                if (!TrySendBattleEntranceArguments(stream,
+                    errCallback,
+                    statusCallback,
+                    serializer,
+                    player))
                 {
-                    Debug.LogWarning($"Incorrect acknowledgement code received");
+                    errCallback("Failed to send battle arguments");
                     name = default;
                     pokemon = default;
                     spriteResourceName = default;
                     return false;
                 }
 
-                //Client sends battle entrance arguments
+                switch (TryReceiveResponseYN(stream, out _))
+                {
+
+                    case false:
+                    case null:
+                        errCallback("Didn't receive yes after sending battle entrance arguments");
+                        name = default;
+                        pokemon = default;
+                        spriteResourceName = default;
+                        return false;
+
+                    case true:
+                        break;
+
+                }
+
                 if (!TryReceiveBattleEntranceArguments(stream,
+                    errCallback,
+                    statusCallback,
                     serializer,
                     out name,
                     out pokemon,
                     out spriteResourceName))
                 {
 
-                    Debug.LogWarning("Failed to receive battle entrance arguments");
+                    errCallback("Failed to receive battle entrance arguments");
+                    SendNo(stream);
                     return false;
 
                 }
 
-                //Server sends acknowledgement
-                SendAck(stream);
+                SendYes(stream);
 
                 return true;
 
             }
             catch (IOException)
             {
-                Debug.LogWarning("Connection lost");
+                errCallback("Connection lost");
                 name = default;
                 pokemon = default;
                 spriteResourceName = default;
                 return false;
             }
+
+        }
+
+        #endregion
+
+        #region Network Battle Comms
+
+        public enum NetworkBattleCommType
+        {
+            Action,
+            ChosenPokemon
+        }
+
+        public struct NetworkBattleComm
+        {
+
+            public NetworkBattleCommType type;
+            public BattleParticipant.Action battleAction; //For actions
+            public int pokemonIndex; //For chosen pokemon
+
+
+            public NetworkBattleComm(BattleParticipant.Action battleAction)
+            {
+                type = NetworkBattleCommType.Action;
+                this.battleAction = battleAction;
+                pokemonIndex = -1;
+            }
+
+            public NetworkBattleComm(int pokemonIndex)
+            {
+                type = NetworkBattleCommType.ChosenPokemon;
+                battleAction = default;
+                this.pokemonIndex = pokemonIndex;
+            }
+
+        }
+
+        private static bool listeningForNetworkBattleComms = false;
+        private static Task listenForNetworkBattleCommsTask = null;
+
+        private static BattleParticipant networkBattleCommActionUser = null;
+        private static BattleParticipant networkBattleCommActionTarget = null;
+
+        #region Network Battle Comms Queue
+
+        private static readonly object recvBattleCommLock = new object();
+        private static Queue<NetworkBattleComm> networkBattleCommsQueue = new Queue<NetworkBattleComm>();
+
+        private static void ClearNetworkBattleCommsQueue()
+        {
+            lock (recvBattleCommLock)
+            {
+                networkBattleCommsQueue.Clear();
+            }
+        }
+
+        private static void EnqueueNetworkBattleComm(NetworkBattleComm comm)
+        {
+            lock (recvBattleCommLock)
+            {
+                networkBattleCommsQueue.Enqueue(comm);
+            }
+        }
+
+        public static NetworkBattleComm? GetNextNetworkBattleComm()
+        {
+            lock (recvBattleCommLock)
+            {
+
+                if (networkBattleCommsQueue.Count > 0)
+                    return networkBattleCommsQueue.Dequeue();
+
+                else
+                    return null;
+
+            }
+        }
+
+        #endregion
+
+        #region Connection Error Occured
+
+        private static readonly object networkCommsConnErrorOccuredLock = new object();
+        private static bool networkCommsConnErrorOccured = false;
+
+        private static void SetNetworkCommsConnErrorOccured(bool state)
+        {
+            lock (networkCommsConnErrorOccuredLock)
+            {
+                networkCommsConnErrorOccured = state;
+            }
+        }
+
+        public static bool NetworkCommsConnErrorOccured
+        {
+            get => networkCommsConnErrorOccured;
+        }
+
+        #endregion
+
+        public static void StartListenForNetworkBattleComms(NetworkStream stream,
+            Serializer serializer,
+            BattleParticipant actionUser,
+            BattleParticipant actionTarget,
+            int refreshDelay = 500)
+        {
+
+            networkBattleCommActionUser = actionUser;
+            networkBattleCommActionTarget = actionTarget;
+
+            if (listenForNetworkBattleCommsTask != null && listenForNetworkBattleCommsTask.Status == TaskStatus.Running)
+            {
+                throw new Exception("Network battle comms listener task already running");
+            }
+
+            ClearNetworkBattleCommsQueue();
+            SetNetworkCommsConnErrorOccured(false);
+            listeningForNetworkBattleComms = true;
+
+            listenForNetworkBattleCommsTask = new Task(() => WaitForRecvAction(stream, serializer, refreshDelay));
+            listenForNetworkBattleCommsTask.Start();
+
+        }
+
+        public static void StopListenForNetworkBattleComms()
+        {
+            listeningForNetworkBattleComms = false;
+        }
+
+        private static void WaitForRecvAction(NetworkStream stream,
+            Serializer serializer,
+            int refreshDelay = 500)
+        {
+
+            while (listeningForNetworkBattleComms)
+            {
+
+                if (stream.CanRead && stream.DataAvailable)
+                {
+                    if (!TryReceiveNetworkBattleComm(stream, serializer, out NetworkBattleComm comm))
+                    {
+                        SetNetworkCommsConnErrorOccured(true);
+                    }
+                    else
+                    {
+                        EnqueueNetworkBattleComm(comm);
+                    }
+                }
+
+                Thread.Sleep(refreshDelay);
+
+            }
+
+        }
+
+        private static bool TryReceiveNetworkBattleComm(NetworkStream stream,
+            Serializer serializer,
+            out NetworkBattleComm comm)
+        {
+
+            switch (ReceiveNetworkBattleCommType(stream))
+            {
+
+                case NetworkBattleCommType.Action:
+
+                    #region Read Action
+
+                    BattleParticipant.Action action = serializer.DeserializeBattleAction(stream,
+                        networkBattleCommActionUser,
+                        networkBattleCommActionTarget);
+                    comm = new NetworkBattleComm(action);
+
+                    #endregion
+
+                    return true;
+
+                case NetworkBattleCommType.ChosenPokemon:
+
+                    #region Read Chosen Pokemon
+
+                    byte[] indexBuffer = new byte[4];
+                    stream.Read(indexBuffer, 0, 4);
+
+                    int index = BitConverter.ToInt32(indexBuffer, 0);
+
+                    comm = new NetworkBattleComm(index);
+
+                    #endregion
+
+                    return true;
+
+                case null:
+                    comm = default;
+                    return false;
+
+                default:
+                    comm = default;
+                    return false;
+
+            }
+
+        }
+
+        public static bool TrySendNetworkBattleAction(NetworkStream stream,
+            Serializer serializer,
+            BattleParticipant.Action action)
+        {
+
+            try
+            {
+
+                SendNetworkBattleCommType(stream, NetworkBattleCommType.Action);
+
+                serializer.SerializeBattleAction(stream, action);
+
+                return true;
+
+            }
+            catch (IOException)
+            {
+                SetNetworkCommsConnErrorOccured(true);
+                return false;
+            }
+
+        }
+
+        public static bool TrySendNetworkBattleNextPokemonIndex(NetworkStream stream,
+            Serializer serializer,
+            int index)
+        {
+
+            SendNetworkBattleCommType(stream, NetworkBattleCommType.ChosenPokemon);
+
+            byte[] buffer = BitConverter.GetBytes(index);
+            stream.Write(buffer, 0, 4);
+
+            return true;
 
         }
 

--- a/Assets/Scripts/Networking/NetworkInteractionCanvas/ConnectionSectionController.cs
+++ b/Assets/Scripts/Networking/NetworkInteractionCanvas/ConnectionSectionController.cs
@@ -68,9 +68,10 @@ namespace Networking.NetworkInteractionCanvas
             NetworkStream stream = Connection.CreateNetworkStream(socket);
 
             //Verify connection
-            if (!Connection.VerifyConnection_Server(stream))
+            if (!Connection.VerifyConnection_Server(stream,
+                errCallback: canvasController.SetStatusMessageError,
+                statusCallback: canvasController.SetStatusMessage))
             {
-                canvasController.SetStatusMessageError("Failed to verify connection as server");
                 stream.Close();
                 Launch(connectionMode); //Reset section
                 yield break;
@@ -78,11 +79,12 @@ namespace Networking.NetworkInteractionCanvas
 
             //Get battle entrance arguments
             if (!Connection.TryExchangeBattleEntranceArguments_Server(stream,
+                errCallback: canvasController.SetStatusMessageError,
+                statusCallback: canvasController.SetStatusMessage,
                 out string opponentName,
                 out PokemonInstance[] opponentPokemon,
                 out string opponentSpriteResourceName))
             {
-                canvasController.SetStatusMessageError("Failed to exchange battle data");
                 stream.Close();
                 Launch(connectionMode); //Reset section
                 yield break;
@@ -103,9 +105,10 @@ namespace Networking.NetworkInteractionCanvas
             NetworkStream stream = Connection.CreateNetworkStream(socket);
 
             //Verify connection
-            if (!Connection.VerifyConnection_Client(stream))
+            if (!Connection.VerifyConnection_Client(stream,
+                errCallback: canvasController.SetStatusMessageError,
+                statusCallback: canvasController.SetStatusMessage))
             {
-                canvasController.SetStatusMessageError("Failed to verify connection as client");
                 stream.Close();
                 Launch(connectionMode); //Reset section
                 yield break;
@@ -113,11 +116,12 @@ namespace Networking.NetworkInteractionCanvas
 
             //Get battle entrance arguments
             if (!Connection.TryExchangeBattleEntranceArguments_Client(stream,
+                errCallback: canvasController.SetStatusMessageError,
+                statusCallback: canvasController.SetStatusMessage,
                 out string opponentName,
                 out PokemonInstance[] opponentPokemon,
                 out string opponentSpriteResourceName))
             {
-                canvasController.SetStatusMessageError("Failed to exchange battle data");
                 stream.Close();
                 Launch(connectionMode); //Reset section
                 yield break;

--- a/Assets/Scripts/Networking/NetworkInteractionCanvas/NetworkInteractionCanvasController.cs
+++ b/Assets/Scripts/Networking/NetworkInteractionCanvas/NetworkInteractionCanvasController.cs
@@ -41,7 +41,7 @@ namespace Networking.NetworkInteractionCanvas
         public void SetStatusMessageError(string s)
             => SetStatusMessage("Error: " + s);
 
-        private object statusMessageLock = new object();
+        private static readonly object statusMessageLock = new object();
 
         public void SetStatusMessage(string s)
         {

--- a/Assets/Scripts/Serialization/Serializer.cs
+++ b/Assets/Scripts/Serialization/Serializer.cs
@@ -4,8 +4,7 @@ using System.IO;
 using UnityEngine;
 using Pokemon;
 using Items;
-using Items.MedicineItems;
-using Items.PokeBalls;
+using Battle;
 
 namespace Serialization {
 
@@ -43,6 +42,7 @@ namespace Serialization {
         public abstract void SerializeInventoryItem(Stream stream, int itemId, int quantity);
         public abstract void SerializePlayerPartyAndStorageSystemPokemon(Stream stream, PlayerData player = null);
         public abstract void SerializeString(Stream stream, string s);
+        public abstract void SerializeBattleAction(Stream stream, BattleParticipant.Action action);
 
         public static void SerializeHeldItem(Stream stream, PokemonInstance pokemon)
         {
@@ -67,8 +67,6 @@ namespace Serialization {
         public static void SerializeByteStats(Stream stream, Stats<byte> stats)
         {
 
-            Debug.Log($"Stats: {stats.attack},{stats.defense},{stats.specialAttack},{stats.specialDefense},{stats.speed},{stats.health}"); //TODO - remove once done debugging
-
             byte[] buffer = new byte[6];
 
             buffer[0] = stats.attack;
@@ -87,16 +85,6 @@ namespace Serialization {
 
             byte[] buffer = new byte[6];
             stream.Read(buffer, 0, 6);
-
-            //TODO - remove once done debugging
-            #region tmp
-
-            string m = "Buffer: ";
-            foreach (byte b in buffer)
-                    m += b.ToString() + ',';
-            Debug.Log(m);
-
-            #endregion
 
             return new Stats<byte>()
             {
@@ -138,18 +126,36 @@ namespace Serialization {
         public Stats<int> DeserializeIntStats(Stream stream)
         {
 
-            byte[] buffer = new byte[24];
-            stream.Read(buffer, 0, 24);
+            int attack, defense, specialAttack, specialDefense, speed, health;
 
-            //Return output
+            byte[] buffer = new byte[4];
+
+            stream.Read(buffer, 0, 4);
+            attack = BitConverter.ToInt32(buffer, 0);
+
+            stream.Read(buffer, 0, 4);
+            defense = BitConverter.ToInt32(buffer, 0);
+
+            stream.Read(buffer, 0, 4);
+            specialAttack = BitConverter.ToInt32(buffer, 0);
+
+            stream.Read(buffer, 0, 4);
+            specialDefense = BitConverter.ToInt32(buffer, 0);
+
+            stream.Read(buffer, 0, 4);
+            speed = BitConverter.ToInt32(buffer, 0);
+
+            stream.Read(buffer, 0, 4);
+            health = BitConverter.ToInt32(buffer, 0);
+
             return new Stats<int>()
             {
-                attack = BitConverter.ToInt32(buffer, 0),
-                defense = BitConverter.ToInt32(buffer, 4),
-                specialAttack = BitConverter.ToInt32(buffer, 8),
-                specialDefense = BitConverter.ToInt32(buffer, 12),
-                speed = BitConverter.ToInt32(buffer, 16),
-                health = BitConverter.ToInt32(buffer, 20),
+                attack = attack,
+                defense = defense,
+                specialAttack = specialAttack,
+                specialDefense = specialDefense,
+                speed = speed,
+                health = health
             };
 
         }
@@ -259,6 +265,10 @@ namespace Serialization {
             out PlayerData.PokemonStorageSystem storageSystem);
 
         public abstract string DeserializeString(Stream stream);
+
+        public abstract BattleParticipant.Action DeserializeBattleAction(Stream stream,
+            BattleParticipant user,
+            BattleParticipant target);
 
         public static Item DeserializeItem(Stream stream)
         {

--- a/Assets/Scripts/Serialization/Serializer_v1.cs
+++ b/Assets/Scripts/Serialization/Serializer_v1.cs
@@ -5,8 +5,7 @@ using System.Text;
 using System.IO;
 using Pokemon;
 using Items;
-using Items.MedicineItems;
-using Items.PokeBalls;
+using Battle;
 
 namespace Serialization
 {
@@ -304,6 +303,35 @@ namespace Serialization
 
             buffer = Encoding.ASCII.GetBytes(s);
             stream.Write(buffer, 0, s.Length);
+
+        }
+
+        public override void SerializeBattleAction(Stream stream, BattleParticipant.Action action)
+        {
+
+            byte[] buffer;
+
+            buffer = BitConverter.GetBytes((int)action.type);
+            stream.Write(buffer, 0, 4);
+
+            SerializeBool(stream, action.fightUsingStruggle);
+
+            buffer = BitConverter.GetBytes(action.fightMoveIndex);
+            stream.Write(buffer, 0, 4);
+
+            buffer = BitConverter.GetBytes(action.switchPokemonIndex);
+            stream.Write(buffer, 0, 4);
+
+            buffer = BitConverter.GetBytes(action.useItemItemToUse.GetId());
+            stream.Write(buffer, 0, 4);
+
+            buffer = BitConverter.GetBytes(action.useItemTargetPartyIndex);
+            stream.Write(buffer, 0, 4);
+
+            buffer = BitConverter.GetBytes(action.useItemTargetMoveIndex);
+            stream.Write(buffer, 0, 4);
+
+            SerializeBool(stream, action.useItemDontConsumeItem);
 
         }
 
@@ -765,6 +793,65 @@ namespace Serialization
             }
 
             return s;
+
+        }
+
+        public override BattleParticipant.Action DeserializeBattleAction(Stream stream,
+            BattleParticipant user,
+            BattleParticipant target)
+        {
+
+            BattleParticipant.Action.Type type;
+            bool fightUsingStruggle, useItemDontConsumeItem;
+            int fightMoveIndex, switchPokemonIndex, useItemTargetPartyIndex, useItemTargetMoveIndex;
+            Item useItemItemToUse;
+
+            byte[] buffer;
+
+            buffer = new byte[4];
+            stream.Read(buffer, 0, 4);
+            type = (BattleParticipant.Action.Type)BitConverter.ToInt32(buffer, 0);
+
+            fightUsingStruggle = DeserializeBool(stream);
+
+            buffer = new byte[4];
+            stream.Read(buffer, 0, 4);
+            fightMoveIndex = BitConverter.ToInt32(buffer, 0);
+
+            buffer = new byte[4];
+            stream.Read(buffer, 0, 4);
+            switchPokemonIndex = BitConverter.ToInt32(buffer, 0);
+
+            buffer = new byte[4];
+            stream.Read(buffer, 0, 4);
+            useItemItemToUse = Item.GetItemById(BitConverter.ToInt32(buffer, 0));
+
+            buffer = new byte[4];
+            stream.Read(buffer, 0, 4);
+            useItemTargetPartyIndex = BitConverter.ToInt32(buffer, 0);
+
+            buffer = new byte[4];
+            stream.Read(buffer, 0, 4);
+            useItemTargetMoveIndex = BitConverter.ToInt32(buffer, 0);
+
+            useItemDontConsumeItem = DeserializeBool(stream);
+
+            return new BattleParticipant.Action(user)
+            {
+
+                type = type,
+                fightUsingStruggle = fightUsingStruggle,
+                fightMoveIndex = fightMoveIndex,
+                switchPokemonIndex = switchPokemonIndex,
+                useItemItemToUse = useItemItemToUse,
+                useItemTargetPartyIndex = useItemTargetPartyIndex,
+                useItemTargetMoveIndex = useItemTargetMoveIndex,
+                useItemDontConsumeItem = useItemDontConsumeItem,
+
+                fightMoveTarget = target,
+                useItemPokeBallTarget = target
+
+            };
 
         }
 


### PR DESCRIPTION
Discard progress made using single-thread network connections as this will create problems later when battles fully implemented.
Instead, concurrent network battle launching has been implemented and will replace the current progress made and the progress that had been made using single-thread network connecting will be replaced later on